### PR TITLE
fix(errors): escaped quotes in returned errors

### DIFF
--- a/src/dev/decRoute.ts
+++ b/src/dev/decRoute.ts
@@ -38,6 +38,7 @@ export type ArrayAlias = number[];
  * alias to a string
  * @example a string
  * @minLength 3
+ * @pattern [abc].*z
  */
 export type StringAlias = string;
 export type AliasAlias = StringAlias;
@@ -170,8 +171,8 @@ export class ThingRoutes extends Controller {
         };
     }
 
-    @Post("other")
-    public test(@Body() input: Burn): ApiRes<string[]> {
+    @Post("other/{test}")
+    public test(@Path() test: StringAlias, @Body() input: Burn): ApiRes<string[]> {
         return {status_code: 1, response_data: ["yay"]};
     }
 }

--- a/src/dev/decTest.ts
+++ b/src/dev/decTest.ts
@@ -71,7 +71,7 @@ function logProvider(parent: Pino.Logger, requestCtx: RequestContext) {
 	});
 }
 
-api.setRequestLogProvider(logProvider);
+// api.setRequestLogProvider(logProvider);
 
 api.post("/v1/w3ut", {
 	summary: "/v1/transactions ",

--- a/src/server/valory.ts
+++ b/src/server/valory.ts
@@ -39,19 +39,20 @@ const flatStr = require("flatstr");
 const ERRORTABLEHEADER = "|Status Code|Name|Description|\n|-|-|--|\n";
 const REDOCPATH = "../../html/index.html";
 
+const QUOTE_REGEX = /"/g;
 const DefaultErrorFormatter: ErrorFormatter = (error, message): ApiResponse => {
 	let finalMessage = (message != null) ? message : error.defaultMessage;
 	if (typeof finalMessage !== "string") {
 		finalMessage = "[";
 		for (let i = 0; i < message.length; i++) {
-			finalMessage += `"${message[i]}"`;
+			finalMessage += `"${message[i].replace(QUOTE_REGEX, '\\"')}"`;
 			if (i + 1 !== message.length) {
 				finalMessage += ",";
 			}
 		}
 		finalMessage += "]";
 	} else {
-		finalMessage = `"${finalMessage}"`;
+		finalMessage = `"${finalMessage.replace(QUOTE_REGEX, '\\"')}"`;
 	}
 	return {
 		statusCode: error.statusCode,

--- a/templates/validatorTemplate.dot
+++ b/templates/validatorTemplate.dot
@@ -50,11 +50,17 @@ var {{= it.hash }} =
             if (keyword =="const") {
                 allowedVal = `: ${getSchemaValue(schemaPath)}`;
             }
+            if(keyword==="pattern"){
+                const split = message.split(" ");
+                const pattern = split[split.length-1];
+                split[split.length-1] = pattern.substring(1,pattern.length-1);
+                message = split.join(" ");
+            }
             if(dataPath.indexOf("+")<0){
                 dataPath = dataPath.replace(/'/g,"");
-                replace = ('\'ValidationError[' + keyword + ']: request' + dataPath + ' ' + message + allowedVal + '\'');
+                replace = (`'ValidationError[${keyword}]: request${dataPath} ${message}${allowedVal}'`);
             } else {
-                replace = ('\'ValidationError[' + keyword + ']: request' + dataPath + ' + \' ' + message + allowedVal + '\'');
+                replace = (`'ValidationError[${keyword}]: request${dataPath} + ' ${message}${allowedVal}'`);
             }
             if(it.singleError){
                 return "return " + replace + ";";
@@ -92,11 +98,17 @@ var {{= it.hash }} =
                     allowedVal = `: ${getSchemaValue(schemaPath)}`;
                 }
             }
+            if(keyword==="pattern"){
+                const split = message.split(" ");
+                const pattern = split[split.length-1];
+                split[split.length-1] = pattern.substring(1,pattern.length-1);
+                message = split.join(" ");
+            }
             if(dataPath.indexOf("+")<0){
                 dataPath = dataPath.replace(/'/g,"");
-                replace = ('\'ValidationError[' + keyword + ']: request' + dataPath + ' ' + message + allowedVal + '\'');
+                replace = (`'ValidationError[${keyword}]: request${dataPath} ${message}${allowedVal}'`);
             } else {
-                replace = ('\'ValidationError[' + keyword + ']: request' + dataPath + ' + \' ' + message + allowedVal + '\'');
+                replace = (`'ValidationError[${keyword}]: request${dataPath} + ' ${message}${allowedVal}'`);
             }
             return "err = "+ replace + ";" + errPush;
       });


### PR DESCRIPTION
The static error serializer was creating invalid JSON when unescaped double quotes appeared in messages.  Additionally, double quotes have been removed from pattern validation messages.

fix #7