### PR TITLE
Add readonly keyword

### DIFF
--- a/documentation/jsdoc-keywords.md
+++ b/documentation/jsdoc-keywords.md
@@ -61,3 +61,7 @@
 
 **@multipleOf [number]**
 * Require numeric property to be a multiple of a given value
+
+**@readonly**
+* Marks a property as readonly, meaning it cannot be sent in a request.
+This will mark the property as optional for requests.

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"tmp": "^0.0.33",
 		"ts-node": "^8.0.2",
 		"tstl": "^2.1.1",
-		"typescript": "^3.2.4",
+		"typescript": "^3.4.5",
 		"xxhashjs": "^0.2.2",
 		"yargs": "^12.0.5"
 	},

--- a/src/dev/decRoute.ts
+++ b/src/dev/decRoute.ts
@@ -30,6 +30,10 @@ export class Burn {
     public literalEnum: LiteralEnum;
     public literal: LiteralAlias;
     public literalNum: LiteralNum;
+	/**
+	 * @readonly
+	 */
+	public id: string;
 }
 
 export type ArrayAlias = number[];

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -198,11 +198,52 @@ describe("ValoryTest", () => {
     }
 
     @suite
+    class DisallowReadonly extends RequestTestBase {
+        private static parsed: any;
+        private static json = {
+            name: "steven",
+            isCool: true,
+            simpleEnum: "thing",
+            id: "some id",
+        };
+
+        public static async before() {
+            await super.before({
+                method: "POST",
+                url: "/test/submit",
+                json: DisallowReadonly.json,
+            });
+            this.parsed = this.response.body;
+        }
+
+        @test
+        public "Should have property code"() {
+            expect(DisallowReadonly.parsed).to.have.property("code");
+        }
+
+        @test
+        public "Should have invalid property error"() {
+            expect(DisallowReadonly.parsed).to.have.property("message")
+                .contains("ValidationError[not]: request.body.id should NOT be valid");
+        }
+    }
+
+    @suite
     class GenericPostTest extends RequestTestBase {
         private static parsed: any;
         private static json = {
             common: "com",
             generic: {
+                name: "steven",
+                isCool: true,
+                simpleEnum: "thing",
+            },
+        };
+
+        private static jsonResponse = {
+            common: "com",
+            generic: {
+                id: "stuff",
                 name: "steven",
                 isCool: true,
                 simpleEnum: "thing",
@@ -225,7 +266,7 @@ describe("ValoryTest", () => {
 
         @test
         public "Should match input"() {
-            expect(GenericPostTest.parsed).to.eql(GenericPostTest.json);
+            expect(GenericPostTest.parsed).to.eql(GenericPostTest.jsonResponse);
         }
 
         @test

--- a/src/test/testRoute.ts
+++ b/src/test/testRoute.ts
@@ -89,6 +89,8 @@ export interface GenericType<T> {
 }
 
 export interface Item {
+	/** @readonly */
+	id: string;
 	name: string;
 	isCool: boolean;
 	simpleEnum: "thing" | "other";
@@ -111,6 +113,7 @@ export class TestRoute extends Controller {
 
 	@Post("submit")
 	public submit(@Body() item: Item) {
+		item.id = "stuff";
 		return item;
 	}
 
@@ -132,6 +135,7 @@ export class TestRoute extends Controller {
 
 	@Post("submit/generic")
 	public submitGeneric(@Body() input: GenericType<Item>) {
+		input.generic.id = "stuff";
 		return input;
 	}
 

--- a/src/tsoa/metadataGeneration/resolveType.ts
+++ b/src/tsoa/metadataGeneration/resolveType.ts
@@ -379,6 +379,12 @@ function getEnumerateType(typeName: ts.EntityName, extractEnum = true): Tsoa.Typ
     }
 }
 
+function getNodeReadOnly(node: ts.PropertyDeclaration | ts.ParameterDeclaration): boolean {
+    return isExistJSDocTag(node, (tag) => {
+        return tag.tagName.text === "readonly";
+    });
+}
+
 function getNodeExample(node: UsableDeclaration | ts.PropertyDeclaration |
     ts.ParameterDeclaration | ts.EnumDeclaration) {
     const example = getJSDocComment(node, "example");
@@ -867,6 +873,7 @@ function getModelProperties(node: UsableDeclaration, genericTypes?: ts.NodeArray
                     format: getNodeFormat(propertyDeclaration),
                     example: getNodeExample(propertyDeclaration),
                     name: identifier.text,
+                    readOnly: getNodeReadOnly(propertyDeclaration),
                     required: !propertyDeclaration.questionToken,
                     type: resolveType(aType, aType.parent),
                     validators: getPropertyValidators(propertyDeclaration),
@@ -948,7 +955,7 @@ function getModelProperties(node: UsableDeclaration, genericTypes?: ts.NodeArray
             if (typeNode.kind === ts.SyntaxKind.TypeReference && genericTypes && genericTypes.length
                 && (node as ts.ClassDeclaration).typeParameters) {
 
-                // The type definitions are conviently located on the object which allow us to map -> to the genericTypes
+                // The type definitions are conveniently located on the object which allow us to map -> to the genericTypes
                 const typeParams = map((node as ts.ClassDeclaration).typeParameters,
                     (typeParam: ts.TypeParameterDeclaration) => {
                         return typeParam.name.text;
@@ -979,6 +986,7 @@ function getModelProperties(node: UsableDeclaration, genericTypes?: ts.NodeArray
                 default: getInitializerValue(property.initializer, type),
                 description: getNodeDescription(property),
                 format: getNodeFormat(property),
+                readOnly: getNodeReadOnly(property),
                 example: getNodeExample(property),
                 name: identifier.text,
                 required: !property.questionToken && !property.initializer,

--- a/src/tsoa/metadataGeneration/tsoa.ts
+++ b/src/tsoa/metadataGeneration/tsoa.ts
@@ -68,6 +68,7 @@ export namespace Tsoa {
 		type: Type;
 		required: boolean;
 		validators: Validators;
+		readOnly: boolean;
 	}
 
 	export interface Type {

--- a/src/tsoa/specGenerator.ts
+++ b/src/tsoa/specGenerator.ts
@@ -289,6 +289,7 @@ export class SpecGenerator {
             swaggerType.description = property.description;
             swaggerType.example = property.example;
             swaggerType.format = format || swaggerType.format;
+            if (property.readOnly) {swaggerType.readOnly = property.readOnly; }
 
             if (property.type.dataType === "object") {
                 const resolved = this.buildLiteralObject(property.type as Tsoa.ObjectType);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compileOnSave": true,
 	"compilerOptions": {
+		"incremental": true,
 		"esModuleInterop": false,
 		"experimentalDecorators": true,
 		"pretty": false,


### PR DESCRIPTION
Add support for swagger readonly using jsdoc keyword.  Readonly properties are not allowed in requests, but will be included in responses.